### PR TITLE
Remove PowerShellGet module and update .Net Core SDK to 2.1.500

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,8 +2,3 @@
 	path = src/Microsoft.PackageManagement.NuGetProvider
 	url = https://github.com/oneget/NuGetProvider.git
 
-[submodule "src/Modules/PowerShellGet"]
-	
-	path = src/Modules/PowerShellGet
-	
-	url = https://github.com/PowerShell/PowerShellGet.git

--- a/Test/run-tests.ps1
+++ b/Test/run-tests.ps1
@@ -83,12 +83,7 @@ if($script:IsWindows)
 #region Step 1 - test setup
 $TestHome = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PSScriptRoot)
 $TestBin = "$($TestHome)\..\src\out\PackageManagement\"
-$PowerShellGetPath = "$($TestHome)\..\src\Modules\PowerShellGet\PowerShellGet"
 $CoreCLRTestHome = "$($TestHome)\..\Test"
-
-# Get PowerShellGet version
-$psGetModuleManifest = Test-ModuleManifest "$PowerShellGetPath\PowerShellGet.psd1"
-$PowerShellGetVersion = $psGetModuleManifest.Version.ToString()
 
 # Get OneGet version
 $packageManagementManifest = Test-ModuleManifest "$TestBin\PackageManagement.psd1"
@@ -125,7 +120,7 @@ else
 }
 
 
-# Setting up Packagemanagement and PowerShellGet folders
+# Setting up Packagemanagement
 if ($testframework -eq "fullclr")
 {    
     $ProgramProviderInstalledPath = "$Env:ProgramFiles\PackageManagement\ProviderAssemblies"
@@ -135,7 +130,6 @@ if ($testframework -eq "fullclr")
 
     $UserModulePath = "$($mydocument)\WindowsPowerShell\Modules"
     $packagemanagementfolder = "$ProgramModulePath\PackageManagement\$PackageManagementVersion"
-    $powershellGetfolder = "$ProgramModulePath\PowerShellGet\$PowerShellGetVersion"
 
     if(-not (Test-Path $packagemanagementfolder)){
         New-Item -Path $packagemanagementfolder -ItemType Directory -Force  
@@ -145,18 +139,7 @@ if ($testframework -eq "fullclr")
         Get-ChildItem -Path $packagemanagementfolder  -Recurse |  Remove-Item -force -Recurse -ErrorAction SilentlyContinue
     }
 
-
-    if(-not (Test-Path $powershellGetfolder)){
-        New-Item -Path $powershellGetfolder -ItemType Directory -Force  
-        Write-Host "Created  $powershellGetfolder"
-    } else{
-        Get-ChildItem -Path $powershellGetfolder | %{ren "$powershellGetfolder\$_" "$powershellGetfolder\$_.deleteMe"}
-        Get-ChildItem -Path $powershellGetfolder  -Recurse |  Remove-Item -force -Recurse
-    }
-
-
-    # Copying files to Packagemanagement and PowerShellGet folders
-    Copy-Item "$PowerShellGetPath\*" $powershellGetfolder -force -verbose
+    # Copying files to Packagemanagement
     Copy-Item "$TestBin\fullclr\*.dll" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.psd1" $packagemanagementfolder -force -Verbose
     Copy-Item "$TestBin\*.psm1" $packagemanagementfolder -force -Verbose

--- a/src/bootstrap.ps1
+++ b/src/bootstrap.ps1
@@ -38,7 +38,7 @@ function Start-DotnetBootstrap {
         # we currently pin dotnet-cli version, because tool
         # is currently migrating to msbuild toolchain
         # and requires constant updates to our build process.
-        [string]$Version = "2.1.4"
+        [string]$Version = "2.1.500"
     )
 
     # Install ours and .NET's dependencies


### PR DESCRIPTION
Not sure if it was a sporadically failing test but the upgrade of the .Net Core SDK seemed to fix or improve it (and the SDK should be updated for security reasons anyway)